### PR TITLE
Don't remove the android tiers skycloud upload hediff.

### DIFF
--- a/Common/Patches/Patches_AndroidTiers.xml
+++ b/Common/Patches/Patches_AndroidTiers.xml
@@ -31,12 +31,13 @@
 					</value>
 				</li>
 				
-				<!-- Prevent pawns from being rescued to MedPods if they are unconscious from the Surrogate Remote Control hediff -->
+				<!-- Prevent pawns from being rescued to MedPods if they are unconscious from the Surrogate Remote Control or Skycloud Upload hediff -->
 				
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ThingDef[@Name="MedPodBedBase"]/comps/li[@Class="MedPod.CompProperties_TreatmentRestrictions"]/usageBlockingHediffs</xpath>
 					<value>
 						<li>ATPP_InRemoteControlMode</li>
+						<li>ATPP_ConsciousnessUpload</li>
 					</value>
 				</li>
 				


### PR DESCRIPTION
Pawns are supposed to be unconcious during skycloud upload.